### PR TITLE
Lower warning default

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -54,7 +54,7 @@ Nothing. We cleanly integrate into the image block, and when you import an image
 
 = Your server has a max upload size of =
 
-This warning shows when your server has a restriction lower than 10MB. Many images provided at the "full" quality are higher than this and therefore will fail when attempting to import. You should be able to contact your hosting provider to increase this value to something more reasonable like 25MB.
+This warning shows when your server has a restriction lower than 3MB. Many images provided at the "full" or "raw" quality are higher than this and therefore will fail when attempting to import. You should be able to contact your hosting provider to increase this value to something more reasonable like 25MB.
 
 == Screenshots ==
 
@@ -62,6 +62,8 @@ This warning shows when your server has a restriction lower than 10MB. Many imag
 2. The default view showing the latest photos
 
 == Changelog ==
+
+- Default to regular size when server upload size is less than 3MB
 
 = 1.1.0 =
 - Add e2e tests of all features

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -68,8 +68,8 @@ export const Loader = ({
         const imageSizeChecked =
             // eslint-disable-next-line
             // @ts-ignore-next-line
-            Number(window?.unlimitedPhotosConfig?.maxUploadSize) < 10
-                ? 'small'
+            Number(window?.unlimitedPhotosConfig?.maxUploadSize) < 3
+                ? 'regular'
                 : imageSize
 
         const newImage: WpImage | undefined = await importImage(

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,10 +19,10 @@ export const Sidebar = ({
     const touched = useRef(false)
 
     useEffect(() => {
-        if (imageSize === 'small') return
+        if (imageSize === 'regular') return
         //  eslint-disable-next-line
         //  @ts-ignore-next-line
-        if (Number(window?.unlimitedPhotosConfig?.maxUploadSize) < 10) {
+        if (Number(window?.unlimitedPhotosConfig?.maxUploadSize) < 3) {
             setShowImportWarning(true)
         }
     }, [imageSize])

--- a/src/state/global.ts
+++ b/src/state/global.ts
@@ -7,7 +7,7 @@ type GlobalState = {
     page: number
     totalPages: number | undefined
     loading: boolean | undefined
-    imageSize: 'full' | 'raw' | 'regular' | 'small'
+    imageSize: 'full' | 'raw' | 'regular'
     setImporting: (loading: string | boolean) => void
     setLoading: (loading: boolean) => void
     setSearchTerm: (searchTerm: string) => void


### PR DESCRIPTION
This lowers when the warning shows from 10MB to 3MB and will serve regular sized images instead of small 